### PR TITLE
Runtime 2308

### DIFF
--- a/org.jamovi.jamovi.json
+++ b/org.jamovi.jamovi.json
@@ -234,6 +234,8 @@
                 }
             ]
         },
+        /* needed by scipy with python 3.11 */
+        "python-deps-scipy.json",
         {
             "name": "python3-scipy",
             "buildsystem": "simple",
@@ -252,8 +254,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/scipy/scipy/releases/download/v1.6.2/scipy-1.6.2.tar.xz",
-                    "sha512": "2253f257d5c55739a47759e039602dc542bd1a068c5883fd2a80a60bc7d3e8372d467d589ae2c83b9a847d0fb76c1fb841208213297db284f142fac98dd33b8e"
+                    "url": "https://github.com/scipy/scipy/releases/download/v1.11.1/scipy-1.11.1.tar.gz",
+                    "sha512": "049c9061ccbf101e6f93e055f905616bc7775fbc51c3af99d8533aedc828c5e55d525ccd98b7299280ed706f3298975f28127de9b66809dfe198b0cc4fef466b"
                 }
             ]
         },

--- a/org.jamovi.jamovi.json
+++ b/org.jamovi.jamovi.json
@@ -181,8 +181,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://nodejs.org/download/release/v14.18.2/node-v14.18.2.tar.xz",
-                    "sha512": "9179321e09e91ae68e8833b57fcd8e76aef11546cb9e75a95dc80480513fef46211f308138c10653a050decc687bb31d7975adb388654bc64d41be625fc2e76b"
+                    "url": "https://nodejs.org/download/release/v18.18.2/node-v18.18.2.tar.xz",
+                    "sha512": "00af3c737d735a320481d764f1c23b1348c0454f2b9700cadb10e087feb47c75e7e9344277bb3149305c3e08ff69d9b17b0da81b1b9d9e978fd830c67858ce92"
                 }
             ],
             "cleanup": [

--- a/python-deps-scipy.json
+++ b/python-deps-scipy.json
@@ -1,0 +1,29 @@
+{
+    "name": "python3-deps-scipy",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=/app pythran ply gast beniget"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/2c/ab/a647b8cc3ac1aa07cde06875157696e4522958fb8363474bce21c302d4d8/pythran-0.14.0.tar.gz",
+            "sha512": "48f76605175f89d27d5d5878cd76c5d7f3096d002c5ca163b556c5b12b7cfac0f9dc4f839e85273000c299944ced13923797826e5983252e7bf53d8511e3ae91"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz",
+            "sha512": "37e39a4f930874933223be58a3da7f259e155b75135f1edd47069b3b40e5e96af883ebf1c8a1bbd32f914a9e92cfc12e29fec05cf61b518f46c1d37421b20008"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/14/e7/50cbac38f77eca8efd39516be6651fdb9f3c4c0fab8cf2cf05f612578737/beniget-0.4.1.tar.gz",
+            "sha512": "c002dec769b070cf02038ce232edb905b66df7095b8ff1030ecae1b3810ebae7c1b9b0c38dd1c651b27afe538f01cfff0e54145c09c8e3318963af6a7c1588eb"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/e4/41/f26f62ebef1a80148e20951a6e9ef4d0ebbe2090124bc143da26e12a934c/gast-0.5.4.tar.gz",
+            "sha512": "a288e2ecc15af2a5d50cb34979995f936e88cdaa4427f809b69015cb6ba98eaffd7ea9eff2dc61dae6f6c2d7d9c5cc6e3e9a5565bd7b1dd308cd39f56087c67d"
+        }
+    ]
+}

--- a/python-deps.json
+++ b/python-deps.json
@@ -2,7 +2,7 @@
     "name": "python3-cython",
     "buildsystem": "simple",
     "build-commands": [
-        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=/app cython protobuf tornado nanomsg PyYAML chardet openpyxl pyexcel-ezodf aiohttp pybind11 setuptools wheel pip"
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=/app cython protobuf tornado nanomsg PyYAML chardet openpyxl pyexcel-ezodf aiohttp pybind11 setuptools wheel pip frozenlist aiosignal"
     ],
     "sources": [
         {
@@ -12,13 +12,13 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/d3/38/adc49a5aca4f644e6322237089fdcf194084f5fe41445e6e632f28b32bf7/Cython-0.29.22.tar.gz",
-            "sha512": "721812b7009049717d907f3b22cc63a28b882a843d3af613ddd5a47a6588fb49ffd4188856ed4a2612f8abe07d35ba29b2143b8ff6d184a99c22328db09e9c27"
+            "url": "https://files.pythonhosted.org/packages/38/db/df0e99d6c5fe19ee5c981d22aad557be4bdeed3ecfae25d47b84b07f0f98/Cython-0.29.36.tar.gz",
+            "sha512": "70a820fca32cbf14b48a2ab0705b1911c0eddf7da9b3aa1c7959f55ad412cc5b7bcbfd38c17d9a02bf0d5be0433abdea92ad7edca5babb84efde978c22edbda6"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/ed/46/e298a50dde405e1c202e316fa6a3015ff9288423661d7ea5e8f22f589071/wheel-0.36.2.tar.gz",
-            "sha512": "73f5c6e77b8c396163b02e12ce7291e32960d771c732d8e97476971201b29e654d53551b2ce17db1fbde5697ced1908607995cac38fe2b61c63aec6abd4b6aaf"
+            "url": "https://files.pythonhosted.org/packages/c0/6c/9f840c2e55b67b90745af06a540964b73589256cb10cc10057c87ac78fc2/wheel-0.37.1.tar.gz",
+            "sha512": "c977a740c17abd1fa4b4c2382a33f3ff887baa4231c36990d988cb8531496074e39744786ef6ac0da9c9af4977bce5b2da145377a3ac15eea918f8125bff66ec"
         },
         {
             "type": "file",
@@ -27,13 +27,13 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/97/e7/af7219a0fe240e8ef6bb555341a63c43045c21ab0392b4435e754b716fa1/yarl-1.6.3.tar.gz",
-            "sha512": "4c76b94198b8e334f4b4e71d92b0fe23f752d35e0c29bc68df99648b3f48fbb6e3dd8d7339138544e5dc8fbf64c15cb61678052670ac47edc5be958df819d42e"
+            "url": "https://files.pythonhosted.org/packages/c4/1e/1b204050c601d5cd82b45d5c8f439cb6f744a2ce0c0a6f83be0ddf0dc7b2/yarl-1.8.2.tar.gz",
+            "sha512": "15150a1771ab8f5d9e4ab7836dcd61ee8a94d427672d8c9dafd1c0de8bfbfbe51d075c93d4b584a2e14a47af131d5e79db6e2d94084bc8fad735ec98cba209c2"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/46/0e/3131a9ae6e6cd1d718cfdd3e2c25f681f2db29be30763aa54b9310de5fea/pybind11-2.6.2.tar.gz",
-            "sha512": "8b76250817ced714445982f936f801b33a9184664f1f9a43ac18c81116361581a0475eda228620c3f3a3f9bd2c681aaa41e8dea0139039c6164332481937d3cb"
+            "url": "https://files.pythonhosted.org/packages/3a/cc/903bb18de90b5d6e15379c97175371ac6414795d94b9c2f6468a9c1303aa/pybind11-2.11.1.tar.gz",
+            "sha512": "5f98b73ac96f08a390d8ba4ace552afaca4d06f5bce62234a1199d400560d1e3fcb17aa04a5a17661228e0eea8880b0a517dddc1f3e6c774d89c5463a628db0f"
         },
         {
             "type": "file",
@@ -62,8 +62,8 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/e5/21/a2e4517e3d216f0051687eea3d3317557bde68736f038a3b105ac3809247/lxml-4.6.3.tar.gz",
-            "sha512": "57489c42257afd00376886d6873c97088778afa8009fa644e2660722d134f346030218c24be6329ee828f73f5164cdd1dad583c17addbdf3e0c84e4d8ab9e176"
+            "url": "https://files.pythonhosted.org/packages/30/39/7305428d1c4f28282a4f5bdbef24e0f905d351f34cf351ceb131f5cddf78/lxml-4.9.3.tar.gz",
+            "sha512": "b5e47d6e7301efa39f6cf07153d3e007dd3d93c32a3a072dca457486305480bc8345896d0c4519064f51e4bc8611c3bb5ba6be426f853509ec12c7b8796d01c5"
         },
         {
             "type": "file",
@@ -87,8 +87,18 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/99/f5/90ede947a3ce2d6de1614799f5fea4e93c19b6520a59dc5d2f64123b032f/aiohttp-3.7.4.post0.tar.gz",
-            "sha512": "1697390a8f40a1de0335343f7c3451a1b772e181364edd30c5834abf5e8f3020bdf3fa4226d435e4c2b73340bea567188089d67a1fc93826e1a51bc5e419f0d7"
+            "url": "https://files.pythonhosted.org/packages/54/07/9467d3f8dae29b14f423b414d9e67512a76743c5bb7686fb05fe10c9cc3e/aiohttp-3.9.1.tar.gz",
+            "sha512": "3288085d5fbcfb7e3664f906345aeab6f989f2318babae6bf5cc3955de48707e9de56ce3b9553d6ee35c72b8f884dc1fd01861a638ee738573e78a203e6a9dec"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/e9/10/d629476346112b85c912527b9080944fd2c39a816c2225413dbc0bb6fcc0/frozenlist-1.3.3.tar.gz",
+            "sha512": "a92c6c0b60eaa66db6f26cef9b3991ab207bb38c5686b66194f61e168f1a1d98d1966d7fe7c800191bb3d2eae8c2dc014819091c78f2bb24e53dc257bba0ed51"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/ae/67/0952ed97a9793b4958e5736f6d2b346b414a2cd63e82d05940032f45b32f/aiosignal-1.3.1.tar.gz",
+            "sha512": "577cda11ffc3a343fadda81e7a037ab4de9cf16e9913124228b53a5e2fd6be4d9b7b3e1d92d61cbc5c472f318eccfa9fae580ca32aad25f42a05231ebea9caa6"
         },
         {
             "type": "file",


### PR DESCRIPTION
I updated quite a few dependencies to build with python-3.11 (it seems the runtime 2308 uses it), the build is still not successfull on my local machine, but it is worthy to try with recent flatpak-builder. Just for a reference, my build stops here:

```
...
Committing stage build-jmvcore to cache
========================================================================
Building module jamovi-electron-app in /home/sources/github_org.jamovi.jamovi/.flatpak-builder/build/jamovi-electron-app-1
========================================================================
Running: cp jamovi /app/bin/jamovi
cp: cannot stat 'jamovi': No such file or directory
Error: module jamovi-electron-app: Child process exited with code 1

```
The versions are below:
```
$ flatpak --version
Flatpak 1.10.7
$ flatpak-builder --version
flatpak-builder 1.0.5
```